### PR TITLE
Refs Taiga story #636 - Have added in an API endpoint for handling an…

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,17 @@ Old method(s): is_valid_location_dest_id
 One of [`location_id`, `location_name`, `location_barcode`] must
 be specified in the request.
 
+### Create stock investigation
+```
+URI: /api/stock-picking-batch/:ident/unpickable
+HTTP Method: POST
+Old method(s): unpickable_item
+```
+* @param ident - id of the batch to mark as having an unpickable move line
+* @param move_line_id - id of the move_line that is unpickable
+For the given batch_id and move_line_id will generate a stock investigation picking for the relevant stock move lines.
+This will create a backorder if necessary.
+
 ## Stock Picking Priorities
 ```
 URI: /api/stock-picking-priorities/

--- a/README.md
+++ b/README.md
@@ -410,14 +410,16 @@ Old method(s): is_valid_location_dest_id
 One of [`location_id`, `location_name`, `location_barcode`] must
 be specified in the request.
 
-### Create stock investigation
+### Create unpickable item
 ```
-URI: /api/stock-picking-batch/:ident/unpickable
+URI: /api/stock-picking-batch/:id/unpickable
 HTTP Method: POST
 Old method(s): unpickable_item
 ```
-* @param ident - id of the batch to mark as having an unpickable move line
+* @param id - id of the batch to mark as having an unpickable move line
 * @param move_line_id - id of the move_line that is unpickable
+* @param reason - string describing the reason that this move line is unpickable
+
 For the given batch_id and move_line_id will generate a stock investigation picking for the relevant stock move lines.
 This will create a backorder if necessary.
 

--- a/controllers/stock_picking_batch.py
+++ b/controllers/stock_picking_batch.py
@@ -160,6 +160,9 @@ class PickingBatchApi(UdesApi):
         Investigation picking will be created for the affected move_lines
         """
         batch = _get_batch(request.env, ident)
+        ResUsers = request.env['res.users']
+        picking_type_id = ResUsers.get_user_warehouse().u_stock_investigation_picking_type.id  # noqa
         unpickable_item = batch.unpickable_item(move_line_id=move_line_id,
-                                                reason=reason)
+                                                reason=reason,
+                                                picking_type_id=picking_type_id)  # noqa
         return unpickable_item

--- a/controllers/stock_picking_batch.py
+++ b/controllers/stock_picking_batch.py
@@ -156,11 +156,11 @@ class PickingBatchApi(UdesApi):
     def unpickable_item(self, ident, move_line_id, reason):
         """
         Creates a Stock Investigation for the specified move_line_id for the
-        given batch.  If necessary a backorder will be created.  A Stock
-        Investigation picking will be created for the affected move_lines
+        given batch.  If necessary a backorder will be created.
         """
-        batch = _get_batch(request.env, ident)
         ResUsers = request.env['res.users']
+
+        batch = _get_batch(request.env, ident)
         picking_type_id = ResUsers.get_user_warehouse().u_stock_investigation_picking_type.id  # noqa
         unpickable_item = batch.unpickable_item(move_line_id=move_line_id,
                                                 reason=reason,

--- a/controllers/stock_picking_batch.py
+++ b/controllers/stock_picking_batch.py
@@ -150,3 +150,16 @@ class PickingBatchApi(UdesApi):
             "Unexpected outcome from the drop off location validation"
 
         return outcome
+
+    @http.route('/api/stock-picking-batch/<ident>/unpickable',
+                type='json', methods=['POST'], auth='user')
+    def unpickable_item(self, ident, move_line_id, reason):
+        """
+        Creates a Stock Investigation for the specified move_line_id for the
+        given batch.  If necessary a backorder will be created.  A Stock
+        Investigation picking will be created for the affected move_lines
+        """
+        batch = _get_batch(request.env, ident)
+        unpickable_item = batch.unpickable_item(move_line_id=move_line_id,
+                                                reason=reason)
+        return unpickable_item


### PR DESCRIPTION
… unpickable move line on a batch picking.  This will create a stock investigation for the affected move lines and create a backorder if necessary.  Also added in functionality for allowing us to get or create a ProcurementGroup