### PR TITLE
Refs Taiga Story #590 (Task #593) - To maintain consistency with the …

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Update/mutate the stock picking
 * @param (optional) result_package_name - If it corresponds to an existing package/pallet that is not in an other location, we will set it to the `result_package_id` of the operations of the picking (i.e. transfer). If the target storage format of the picking type is pallet of packages it will set `result_parent_package_id`.
 * @param (optional) package_name - Name of the package of the picking that has been effectively scanned, to be marked as done.
 * @param (optional) expected_package_name - Name of the package that was expected to be scanned as part of the picking, to be swapped with the `package_name`.
-* @param (optional) products_info - An array with the products information to be marked as done, where each dictionary contains: product_barcode, qty and serial numbers if needed
+* @param (optional) product_uds - An array with the products information to be marked as done, where each dictionary contains: barcode, qty and lot numbers if needed
 * @param (optional) u_transport_id - A dictionary of transport information to update the stock picking with
 
 Api call example to mark as done one unit of product test01 from picking with id 60.

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Update/mutate the stock picking
 * @param (optional) result_package_name - If it corresponds to an existing package/pallet that is not in an other location, we will set it to the `result_package_id` of the operations of the picking (i.e. transfer). If the target storage format of the picking type is pallet of packages it will set `result_parent_package_id`.
 * @param (optional) package_name - Name of the package of the picking that has been effectively scanned, to be marked as done.
 * @param (optional) expected_package_name - Name of the package that was expected to be scanned as part of the picking, to be swapped with the `package_name`.
-* @param (optional) product_uds - An array with the products information to be marked as done, where each dictionary contains: barcode, qty and lot numbers if needed
+* @param (optional) product_ids - An array with the products information to be marked as done, where each dictionary contains: barcode, qty and lot numbers if needed
 * @param (optional) u_transport_id - A dictionary of transport information to update the stock picking with
 
 Api call example to mark as done one unit of product test01 from picking with id 60.

--- a/models/stock_move_line.py
+++ b/models/stock_move_line.py
@@ -9,17 +9,17 @@ from odoo.exceptions import ValidationError
 class StockMoveLine(models.Model):
     _inherit = 'stock.move.line'
 
-    def mark_as_done(self, location_dest=None, result_package=None, package=None, products_info=None):
+    def mark_as_done(self, location_dest=None, result_package=None, package=None, product_ids=None):
         """ Extend mark_as_done function to handle another level of packages and
             use u_target_storage_format.
         """
         result_package, parent_package = \
-                self._prepare_result_packages(package, result_package, products_info)
+                self._prepare_result_packages(package, result_package, product_ids)
 
         res = super(StockMoveLine, self).mark_as_done(location_dest=location_dest,
                                                       result_package=result_package,
                                                       package=package,
-                                                      products_info=products_info)
+                                                      product_ids=product_ids)
 
         if parent_package:
             res.write({'u_result_parent_package_id': parent_package.id})


### PR DESCRIPTION
…database layer we have renamed "products_info" to be "product_ids".  The keys in the containing data have also been renamed to better reflect the database fields.  This necessitates refactoring variable names in a few model methods to keep things consistent.